### PR TITLE
display 304s

### DIFF
--- a/public/feature/header/IndexController.js
+++ b/public/feature/header/IndexController.js
@@ -84,7 +84,6 @@ app.controller( 'HeaderIndexController', function( $rootScope, $scope, $http ) {
   $scope.search = '';
   $scope.results = [];
   $scope.currentText = '';
-  $scope.lastSuggest = 0;
   $scope.lastSearch = 0;
 
   $scope.selectResult = function( result ){
@@ -117,10 +116,6 @@ app.controller( 'HeaderIndexController', function( $rootScope, $scope, $http ) {
 
         // prevent showing suggestions when input is blank
         if( !$scope.search.length ) return;
-
-        // prevent older results loading over newer ones
-        if( data.date < $scope.lastSuggest ) return;
-        $scope.lastSuggest = data.date;
 
         $scope.results.length = 0;
         $scope.results = data.body.map( function( res ){


### PR DESCRIPTION
Since the cached responses (304s) carry an old date, we cannot expect every response to have a newer date than the previous.

---

https://trello.com/c/x1n7WtOK/67-sporadic-autocomplete-drop-down

Issue:

http://pelias.mapzen.com

Do some searches, backspace over previously entered characters, re-enter them. I frequently do not get a dropdown rendered, despite the server response being either a 200 or a 304.
